### PR TITLE
Fixes bug that prevented saving moments with similar items

### DIFF
--- a/client/www/app/core/data/datahandler.js
+++ b/client/www/app/core/data/datahandler.js
@@ -80,6 +80,11 @@
         moment.content = updatedContent;        
         MomentModel.set(moment);
         return moment.ID;
+      })
+      .catch(function(err) {
+        console.error('There was an error uploading Items to S3.');
+        console.error(err);
+        return err;
       });
     }
 

--- a/client/www/app/core/data/dataservice.js
+++ b/client/www/app/core/data/dataservice.js
@@ -183,27 +183,38 @@
     function uploadItem(item, sessionID) {            
       return $http({
         method: 'GET',
-        url: hostURL + '/s3?s3_object_type=' + item.type,
+        url: hostURL + '/s3?s3_object_type=' + item.type,        
         headers: {
           'Content-Type': 'application/json',
+          'sessionID': sessionID,
+          'Cache-Control': 'no-cache'
+        },
+        // Since we're potentially sending multiple similar request to the server,
+        // we need to put on some information that's unique for each request along with
+        // 'Cache-Control' : 'no-cache' in the headers.
+        params: {
+          'timestamp': new Date().valueOf(),
           'sessionID': sessionID
         }
       })
-        .success(function(result){
-          console.log('Succesful getting S3 url');
-          // utilizes upload service to upload moment item to S3
-          return upload.S3Upload(item.payload, item.type, result.signed_request)
-            .then(function(S3data) {
-              return S3data;
-            })
-            .catch(function(err) {
-              console.log('There was an error uploading moment item to S3', err);
-            });
-        })
-        .error(function(error){
-          console.log('There was an error getting S3 url');
-          throw error;
-        });
+      .success(function(result){
+        console.log('Succesful getting S3 url');
+        // utilizes upload service to upload moment item to S3
+        console.log('This is the request that was received by the server: ');
+        console.log(result.signed_request);
+
+        return upload.S3Upload(item.payload, item.type, result.signed_request)
+          .then(function(S3data) {
+            return S3data;
+          })
+          .catch(function(err) {
+            console.log('There was an error uploading moment item to S3', err);
+          });
+      })
+      .error(function(error){
+        console.log('There was an error getting S3 url');
+        throw error;
+      });
     }
         
     function saveMemento(memento, sessionID) {      

--- a/client/www/app/core/data/upload.js
+++ b/client/www/app/core/data/upload.js
@@ -26,7 +26,7 @@
         data: payload
       })
       .success(function(data, status, headers, config) {
-        console.log('Succesful uploading moment item to S3');
+        console.log('Succesful uploading moment item to S3');        
       })
       .error(function(data, status, headers, config) {
         console.log('There was an error uploading moment item to S3');


### PR DESCRIPTION
We were making the same exact GET request to the server for similar
item types. The browser was caching these requests by default and only
sending out one request.
