### PR TITLE
Fixes routing to 'received' memento

### DIFF
--- a/client/www/app/app.module.js
+++ b/client/www/app/app.module.js
@@ -90,7 +90,7 @@
       })
         // nested state
         .state('memento', {
-          url: '/mementos/:ID',
+          url: '/mementos/{viewer}/:ID',
           templateUrl: 'app/memento/memento.html',
           controller: 'Memento as vm'
         })

--- a/client/www/app/core/data/MementosModel.js
+++ b/client/www/app/core/data/MementosModel.js
@@ -19,7 +19,6 @@
       set: set,
       reset: reset,
       getAll: getAll,
-      findByViewer: findByViewer,
       updateOrInsert: updateOrInsert,
       isUpdating: true
     };
@@ -68,7 +67,7 @@
       }
     }
 
-    function findByViewer(ID, viewer) {
+    function get(ID, viewer) {
       var memento;
       var i;
 
@@ -79,11 +78,6 @@
         }
       }
       return null;
-    }
-
-    function get(ID) {      
-      var mementoInCreated = findByViewer(ID, 'created');
-      return  mementoInCreated ? mementoInCreated : findByViewer(ID, 'received');
     }
   }
 

--- a/client/www/app/memento-create/memento.create.js
+++ b/client/www/app/memento-create/memento.create.js
@@ -69,7 +69,10 @@
 
       Events.trigger('newMemento');
       vm.currentMemento = new DataHandler.memento.constructor();      
-      $state.go('memento', { ID: memento.ID });
+      $state.go('memento', { 
+        ID: memento.ID,
+        viewer: 'created'
+      });
     }
 
     function addMomentToMemento(moment) {

--- a/client/www/app/memento/memento.html
+++ b/client/www/app/memento/memento.html
@@ -19,8 +19,7 @@
       <div class="moment-release-date">Release Date: {{moment.releaseDate | date: 'MMM d, y h:mm a'}}</div>
       
       <div ng-repeat="item in moment.content">
-        
-        <show-text ng-if="item.type === 'text/plain'"></show-text>
+        <show-text  ng-if="item.type === 'text/plain'"></show-text>
         <show-image ng-if="item.type === 'image/jpeg'"></show-image>
       </div>
     

--- a/client/www/app/memento/memento.js
+++ b/client/www/app/memento/memento.js
@@ -10,7 +10,8 @@
     /*jshint validthis: true */
     var vm = this;
     vm.mementoID = Number($stateParams.ID);
-    vm.memento = {};
+    vm.viewer    = $stateParams.viewer;
+    vm.memento   = {};
     
     vm.getMemento       = getMemento;
     vm.normalizeDate    = normalizeDate;
@@ -28,7 +29,7 @@
 
       Events.on('newMoment', function() {
         vm.getMemento();
-      })
+      });
     }
 
     function normalizeDate(moment) {
@@ -36,7 +37,7 @@
     }
 
     function getMemento() {
-      vm.memento = DataHandler.mementos.get(vm.mementoID);
+      vm.memento = DataHandler.mementos.get(vm.mementoID, vm.viewer);
     }
 
     function goToMementos () {
@@ -74,4 +75,3 @@
     
   }
 })();
-

--- a/client/www/app/mementos-list/mementos.html
+++ b/client/www/app/mementos-list/mementos.html
@@ -20,7 +20,7 @@
       
       <div class="item item-divider received-mementos">Received</div>
 
-      <ion-item ng-repeat="memento in vm.mementos.received" class="item-icon-left left-memento-icon" on-tap="vm.goToMemento({{memento.ID}})">
+      <ion-item ng-repeat="memento in vm.mementos.received" class="item-icon-left left-memento-icon" on-tap="vm.goToMemento({{memento.ID}}, 'received')">
         <i class="icon ion-ios7-moon memento-icon-received"></i>
         {{memento.title}}
       </ion-item>

--- a/client/www/app/mementos-list/mementos.js
+++ b/client/www/app/mementos-list/mementos.js
@@ -54,7 +54,8 @@
     }
 
     function addMoment(mementoID) {
-      var memento = DataHandler.mementos.get(mementoID);
+      var memento = DataHandler.mementos.get(mementoID, 'created');
+      vm.moment   = DataHandler.moment.get();
 
       if (vm.moment.hasOwnProperty('ID')) {
         DataHandler.memento.set(memento);      
@@ -71,9 +72,9 @@
         })
         .catch(function(err) {
           console.error('There was an error updating the memento:', err);
-        })
+        });
       } else {
-        vm.goToMemento(memento.ID);
+        vm.goToMemento(memento.ID, 'created');
       }
     }
     
@@ -87,9 +88,12 @@
       }
     }
 
-    function goToMemento(mementoID) {      
-      $state.go('memento', {ID: mementoID});
-    }    
+    function goToMemento(mementoID, viewer) {
+      $state.go('memento', {
+        ID: mementoID,
+        viewer: viewer
+      });
+    }
     
     function goToMomentCreate () {
 

--- a/client/www/app/moment/moment.create.html
+++ b/client/www/app/moment/moment.create.html
@@ -37,6 +37,7 @@
     </button>
     
 
+
     <button ng-disabled="!vm.currentMoment.title || !vm.currentMoment.content[0] || !vm.date || !vm.time" class="button button-outline button-large button-block button-positive m-save" on-tap="vm.saveMoment(vm.currentMoment)">Save</button>
 
   </ion-content>


### PR DESCRIPTION
There was a problem in the way that mementos were fetched from the Mementos Model. Now we're able to go to a memento based on the viewer type: 'created' or 'received'.
